### PR TITLE
remove old node support due to koa-bodyparser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
-  - "6"
   - "7"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "license": "MIT",
   "engines": {
-    "node": ">= 4"
+    "node": ">= 7.6"
   },
   "devDependencies": {
     "koa-bodyparser": "^4.1.0",


### PR DESCRIPTION
koa-bodyparser requires node >= 7.6